### PR TITLE
redis db option + return the cached value from setter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-redis-anyway",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A Redis cache management plugin for n8n with intelligent cache handling and proactive renewal",
   "keywords": [
     "n8n",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dkavraal/n8n-nodes-redis-anyway",
-  "version": "0.1.13",
+  "version": "0.1.15",
   "description": "A Redis cache management plugin for n8n with intelligent cache handling and proactive renewal",
   "keywords": [
     "n8n",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "n8n-nodes-redis-anyway",
+  "name": "@dkavraal/n8n-nodes-redis-anyway",
   "version": "0.1.13",
   "description": "A Redis cache management plugin for n8n with intelligent cache handling and proactive renewal",
   "keywords": [

--- a/src/credentials/Redis.credentials.ts
+++ b/src/credentials/Redis.credentials.ts
@@ -57,6 +57,7 @@ export class Redis implements ICredentialType {
       name: 'db',
       type: 'number',
       default: 0,
+      required: true,
       description: '',
     }
   ];

--- a/src/credentials/Redis.credentials.ts
+++ b/src/credentials/Redis.credentials.ts
@@ -51,6 +51,13 @@ export class Redis implements ICredentialType {
       type: 'boolean',
       default: false,
       description: 'Ativar conexão segura via TLS/SSL',
+    },
+    {
+      displayName: 'Database',
+      name: 'db',
+      type: 'number',
+      default: 0,
+      description: '',
     }
   ];
 
@@ -58,12 +65,4 @@ export class Redis implements ICredentialType {
     type: 'generic',
     properties: {},
   };
-
-  test: ICredentialTestRequest = {
-    request: {
-      baseURL: '=http://{{$credentials.host}}:{{$credentials.port}}',
-      method: 'HEAD',
-      timeout: 5000,
-    },
-  };
-} 
+}

--- a/src/credentials/Redis.credentials.ts
+++ b/src/credentials/Redis.credentials.ts
@@ -54,7 +54,7 @@ export class Redis implements ICredentialType {
     },
     {
       displayName: 'Database',
-      name: 'db',
+      name: 'database',
       type: 'number',
       default: 0,
       required: true,

--- a/src/nodes/RedisAnyway/GetCache.node.ts
+++ b/src/nodes/RedisAnyway/GetCache.node.ts
@@ -31,6 +31,7 @@ export class GetCache implements INodeType {
       {
         name: 'redis',
         required: true,
+        testedBy: 'redisConnectionTest', // see: https://github.com/n8n-io/n8n/blob/ae8cbbba2efe328eea5d43661cb634aa3f84099c/packages/nodes-base/nodes/Redis/Redis.node.ts#L37
       },
     ],
     properties: [
@@ -71,6 +72,7 @@ export class GetCache implements INodeType {
         username: credentials.username !== 'DEFAULT' ? credentials.username as string : undefined,
         password: credentials.password ? credentials.password as string : undefined,
         tls: credentials.useTls === true ? {} : undefined,
+        db: credentials.db as number,
       };
       
       RedisConnection.initialize(redisOptions);

--- a/src/nodes/RedisAnyway/GetCache.node.ts
+++ b/src/nodes/RedisAnyway/GetCache.node.ts
@@ -87,7 +87,7 @@ export class GetCache implements INodeType {
         username: credentials.username !== 'DEFAULT' ? credentials.username as string : undefined,
         password: credentials.password ? credentials.password as string : undefined,
         tls: credentials.useTls === true ? {} : undefined,
-        db: (credentials.db ?? credentials.database) as number,
+        db: credentials.database as number,
       };
       
       RedisConnection.initialize(redisOptions);

--- a/src/nodes/RedisAnyway/GetCache.node.ts
+++ b/src/nodes/RedisAnyway/GetCache.node.ts
@@ -9,6 +9,21 @@ import {
 } from 'n8n-workflow';
 import { RedisConnection } from './RedisConnection';
 
+const NodeConnectionTypeValue = {
+  AiAgent: "ai_agent",
+  AiChain: "ai_chain",
+  AiDocument: "ai_document",
+  AiEmbedding: "ai_embedding",
+  AiLanguageModel: "ai_languageModel",
+  AiMemory: "ai_memory",
+  AiOutputParser: "ai_outputParser",
+  AiRetriever: "ai_retriever",
+  AiTextSplitter: "ai_textSplitter",
+  AiTool: "ai_tool",
+  AiVectorStore: "ai_vectorStore",
+  Main: "main"
+} as const;
+
 export class GetCache implements INodeType {
   description: INodeTypeDescription = {
     displayName: 'Redis Get Cache',
@@ -21,11 +36,11 @@ export class GetCache implements INodeType {
     defaults: {
       name: 'Get Cache',
     },
-    inputs: [{ type: NodeConnectionType.Main }],
+    inputs: [{ type: NodeConnectionTypeValue.Main as NodeConnectionType }],
     outputs: [
-      { type: NodeConnectionType.Main, displayName: 'Valid Cache' },
-      { type: NodeConnectionType.Main, displayName: 'Invalid Cache' },
-      { type: NodeConnectionType.Main, displayName: 'Needs Renewal' },
+      { type: NodeConnectionTypeValue.Main as NodeConnectionType, displayName: 'Valid Cache' },
+      { type: NodeConnectionTypeValue.Main as NodeConnectionType, displayName: 'Invalid Cache' },
+      { type: NodeConnectionTypeValue.Main as NodeConnectionType, displayName: 'Needs Renewal' },
     ],
     credentials: [
       {
@@ -72,7 +87,7 @@ export class GetCache implements INodeType {
         username: credentials.username !== 'DEFAULT' ? credentials.username as string : undefined,
         password: credentials.password ? credentials.password as string : undefined,
         tls: credentials.useTls === true ? {} : undefined,
-        db: credentials.db as number,
+        db: (credentials.db ?? credentials.database) as number,
       };
       
       RedisConnection.initialize(redisOptions);

--- a/src/nodes/RedisAnyway/ManipulateCache.node.ts
+++ b/src/nodes/RedisAnyway/ManipulateCache.node.ts
@@ -9,6 +9,21 @@ import {
 import { RedisConnection } from './RedisConnection';
 import { redisConnectionTest } from './util';
 
+const NodeConnectionTypeValue = {
+  AiAgent: "ai_agent",
+  AiChain: "ai_chain",
+  AiDocument: "ai_document",
+  AiEmbedding: "ai_embedding",
+  AiLanguageModel: "ai_languageModel",
+  AiMemory: "ai_memory",
+  AiOutputParser: "ai_outputParser",
+  AiRetriever: "ai_retriever",
+  AiTextSplitter: "ai_textSplitter",
+  AiTool: "ai_tool",
+  AiVectorStore: "ai_vectorStore",
+  Main: "main"
+} as const;
+
 export class ManipulateCache implements INodeType {
   description: INodeTypeDescription = {
     displayName: 'Redis Manipulate Cache',
@@ -21,8 +36,8 @@ export class ManipulateCache implements INodeType {
     defaults: {
       name: 'Manipulate Cache',
     },
-    inputs: [{ type: NodeConnectionType.Main }],
-    outputs: [{ type: NodeConnectionType.Main }],
+    inputs: [{ type: NodeConnectionTypeValue.Main as NodeConnectionType }],
+    outputs: [{ type: NodeConnectionTypeValue.Main as NodeConnectionType }],
     credentials: [
       {
         name: 'redis',
@@ -137,7 +152,7 @@ export class ManipulateCache implements INodeType {
         username: credentials.username !== 'DEFAULT' ? credentials.username as string : undefined,
         password: credentials.password ? credentials.password as string : undefined,
         tls: credentials.useTls === true ? {} : undefined,
-        db: credentials.db as number,
+        db: (credentials.db ?? credentials.database) as number,
       };
       
       RedisConnection.initialize(redisOptions);

--- a/src/nodes/RedisAnyway/ManipulateCache.node.ts
+++ b/src/nodes/RedisAnyway/ManipulateCache.node.ts
@@ -152,7 +152,7 @@ export class ManipulateCache implements INodeType {
         username: credentials.username !== 'DEFAULT' ? credentials.username as string : undefined,
         password: credentials.password ? credentials.password as string : undefined,
         tls: credentials.useTls === true ? {} : undefined,
-        db: (credentials.db ?? credentials.database) as number,
+        db: credentials.database as number,
       };
       
       RedisConnection.initialize(redisOptions);

--- a/src/nodes/RedisAnyway/ManipulateCache.node.ts
+++ b/src/nodes/RedisAnyway/ManipulateCache.node.ts
@@ -7,6 +7,7 @@ import {
   NodeConnectionType,
 } from 'n8n-workflow';
 import { RedisConnection } from './RedisConnection';
+import { redisConnectionTest } from './util';
 
 export class ManipulateCache implements INodeType {
   description: INodeTypeDescription = {
@@ -119,6 +120,10 @@ export class ManipulateCache implements INodeType {
     ],
   };
 
+  methods = {
+    credentialTest: { redisConnectionTest },
+  };
+
   async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
     const items = this.getInputData();
     const returnData: INodeExecutionData[] = [];
@@ -132,6 +137,7 @@ export class ManipulateCache implements INodeType {
         username: credentials.username !== 'DEFAULT' ? credentials.username as string : undefined,
         password: credentials.password ? credentials.password as string : undefined,
         tls: credentials.useTls === true ? {} : undefined,
+        db: credentials.db as number,
       };
       
       RedisConnection.initialize(redisOptions);

--- a/src/nodes/RedisAnyway/RedisConnection.ts
+++ b/src/nodes/RedisAnyway/RedisConnection.ts
@@ -40,7 +40,8 @@ export class RedisConnection {
       port: RedisConnection.connectionOptions.port,
       username: RedisConnection.connectionOptions.username ? '(set)' : '(not set)',
       password: RedisConnection.connectionOptions.password ? '(set)' : '(not set)',
-      tls: RedisConnection.connectionOptions.tls ? '(enabled)' : '(disabled)'
+      tls: RedisConnection.connectionOptions.tls ? '(enabled)' : '(disabled)',
+      db: RedisConnection.connectionOptions.db,
     });
   }
 
@@ -56,7 +57,7 @@ export class RedisConnection {
       RedisConnection.instance = null;
       
       RedisConnection.instance = new IORedis(RedisConnection.connectionOptions);
-      
+
       // Eventos de conexão
       RedisConnection.instance.on('connect', () => {
         console.log('Redis: Connected to server, authentification pending');

--- a/src/nodes/RedisAnyway/SetCache.node.ts
+++ b/src/nodes/RedisAnyway/SetCache.node.ts
@@ -8,6 +8,21 @@ import {
 } from 'n8n-workflow';
 import { RedisConnection } from './RedisConnection';
 
+const NodeConnectionTypeValue = {
+  AiAgent: "ai_agent",
+  AiChain: "ai_chain",
+  AiDocument: "ai_document",
+  AiEmbedding: "ai_embedding",
+  AiLanguageModel: "ai_languageModel",
+  AiMemory: "ai_memory",
+  AiOutputParser: "ai_outputParser",
+  AiRetriever: "ai_retriever",
+  AiTextSplitter: "ai_textSplitter",
+  AiTool: "ai_tool",
+  AiVectorStore: "ai_vectorStore",
+  Main: "main"
+} as const;
+
 export class SetCache implements INodeType {
   description: INodeTypeDescription = {
     displayName: 'Redis Set Cache',
@@ -20,8 +35,8 @@ export class SetCache implements INodeType {
     defaults: {
       name: 'Set Cache',
     },
-    inputs: [{ type: NodeConnectionType.Main }],
-    outputs: [{ type: NodeConnectionType.Main }],
+    inputs: [{ type: NodeConnectionTypeValue.Main as NodeConnectionType }],
+    outputs: [{ type: NodeConnectionTypeValue.Main as NodeConnectionType }],
     credentials: [
       {
         name: 'redis',

--- a/src/nodes/RedisAnyway/SetCache.node.ts
+++ b/src/nodes/RedisAnyway/SetCache.node.ts
@@ -175,7 +175,7 @@ export class SetCache implements INodeType {
         username: credentials.username !== 'DEFAULT' ? credentials.username as string : undefined,
         password: credentials.password ? credentials.password as string : undefined,
         tls: credentials.useTls === true ? {} : undefined,
-        db: credentials.db as number,
+        db: credentials.database as number,
       };
       
       RedisConnection.initialize(redisOptions);

--- a/src/nodes/RedisAnyway/util.ts
+++ b/src/nodes/RedisAnyway/util.ts
@@ -1,0 +1,27 @@
+import {
+  ICredentialTestFunctions,
+  INodeCredentialTestResult,
+  ICredentialsDecrypted,
+} from 'n8n-workflow';
+
+import IORedis from 'ioredis';
+
+export async function redisConnectionTest(
+  this: ICredentialTestFunctions,
+  credential: ICredentialsDecrypted,
+): Promise<INodeCredentialTestResult> {
+  try {
+    const client = new IORedis(credential);
+    await client.connect();
+    await client.ping();
+    return {
+      status: 'OK',
+      message: 'Connection successful!',
+    };
+  } catch (error) {
+    return {
+      status: 'Error',
+      message: `${error}`,
+    };
+  }
+}


### PR DESCRIPTION
1. It wasn't working for me, so I had to remove connection test.

2. Added Redis database number option to the connection.

3. To accomodate a replacable piece with "Get Cache" node, I made a change on "Set Cache" so that it returns the cached value. Thus the down stream can do the stuff without concerning if it was from cache or DB. In both case the value will return in "value" field.
```mermaid
flowchart LR
    A[Event Source] --> B[Get Cache]
    B --> |Cache Hit| E[FUNC: Do stuff with event and cached value]
    B --> |Cache Miss| F[Get From DB]
    F --> G[Set Cache]
    G --> E
```
